### PR TITLE
Add Err and Err2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Modver
         if: ${{ github.event_name == 'pull_request' }}
-        uses: bobg/modver@v2.10.0
+        uses: bobg/modver@v2.11.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pull_request_url: https://github.com/${{ github.repository }}/pull/${{ github.event.number }}

--- a/accum.go
+++ b/accum.go
@@ -22,19 +22,20 @@ func Accum[T, A any](inp iter.Seq[T], init A, f func(A, T) A) iter.Seq[A] {
 // The error pointer that Accumx returns may be dereferenced to discover that error,
 // but only after the output iterator is fully consumed.
 func Accumx[T, A any](inp iter.Seq[T], init A, f func(A, T) (A, error)) (iter.Seq[A], *error) {
-	var err error
-
-	seq := func(yield func(A) bool) {
+	return Err(func(yield func(A) bool) error {
 		acc := init
 		for val := range inp {
+			var err error
 			acc, err = f(acc, val)
-			if err != nil || !yield(acc) {
-				return
+			if err != nil {
+				return err
+			}
+			if !yield(acc) {
+				return nil
 			}
 		}
-	}
-
-	return seq, &err
+		return nil
+	})
 }
 
 // Accum2 repeatedly applies a function to the elements of a pairwise iterator
@@ -57,17 +58,18 @@ func Accum2[T, U, A any](inp iter.Seq2[T, U], init A, f func(A, T, U) A) iter.Se
 // The error pointer that Accum2x returns may be dereferenced to discover that error,
 // but only after the output iterator is fully consumed.
 func Accum2x[T, U, A any](inp iter.Seq2[T, U], init A, f func(A, T, U) (A, error)) (iter.Seq[A], *error) {
-	var err error
-
-	seq := func(yield func(A) bool) {
+	return Err(func(yield func(A) bool) error {
 		acc := init
 		for t, u := range inp {
+			var err error
 			acc, err = f(acc, t, u)
-			if err != nil || !yield(acc) {
-				return
+			if err != nil {
+				return err
+			}
+			if !yield(acc) {
+				return nil
 			}
 		}
-	}
-
-	return seq, &err
+		return nil
+	})
 }

--- a/chan.go
+++ b/chan.go
@@ -23,27 +23,22 @@ func FromChan[T any](inp <-chan T) iter.Seq[T] {
 // (such as [context.Canceled] or [context.DeadlineExceeded]),
 // but only after iteration is done.
 func FromChanContext[T any](ctx context.Context, inp <-chan T) (iter.Seq[T], *error) {
-	var err error
-
-	f := func(yield func(T) bool) {
+	return Err(func(yield func(T) bool) error {
 		for {
 			select {
 			case val, ok := <-inp:
 				if !ok {
-					return
+					return nil
 				}
 				if !yield(val) {
-					return
+					return nil
 				}
 
 			case <-ctx.Done():
-				err = ctx.Err()
-				return
+				return ctx.Err()
 			}
 		}
-	}
-
-	return f, &err
+	})
 }
 
 // ToChan launches a goroutine that consumes an iterator and sends its values to a channel.

--- a/err.go
+++ b/err.go
@@ -1,0 +1,39 @@
+package seqs
+
+import "iter"
+
+// Err converts an error-returning function into a Go iterator
+// (i.e., an iter.Seq[T])
+// plus an error pointer.
+//
+// The function being converted must be a func(func(T) bool) error.
+// (An iter.Seq[T] is a func(func(T) bool), without the error result.)
+//
+// The resulting error pointer is never nil,
+// but the error it points to is not guaranteed to be populated
+// until after the iterator has been fully consumed.
+func Err[T any](f func(yield func(T) bool) error) (iter.Seq[T], *error) {
+	var err error
+	result := func(yield func(T) bool) {
+		err = f(yield)
+	}
+	return result, &err
+}
+
+// Err2 converts an error-returning function into a Go iterator
+// (i.e., an iter.Seq2[T, U])
+// plus an error pointer.
+//
+// The function being converted must be a func(func(T, U) bool) error.
+// (An iter.Seq2[T, U] is a func(func(T, U) bool), without the error result.)
+//
+// The resulting error pointer is never nil,
+// but the error it points to is not guaranteed to be populated
+// until after the iterator has been fully consumed.
+func Err2[T, U any](f func(yield func(T, U) bool) error) (iter.Seq2[T, U], *error) {
+	var err error
+	result := func(yield func(T, U) bool) {
+		err = f(yield)
+	}
+	return result, &err
+}

--- a/lines.go
+++ b/lines.go
@@ -13,22 +13,18 @@ import (
 // The caller can dereference the returned error pointer to check for errors
 // but only after iteration is done.
 func Words(r io.Reader) (iter.Seq[string], *error) {
-	var err error
-
-	f := func(yield func(string) bool) {
+	return Err(func(yield func(string) bool) error {
 		sc := bufio.NewScanner(r)
 		sc.Split(bufio.ScanWords)
 
-		defer func() { err = sc.Err() }()
-
 		for sc.Scan() {
 			if !yield(sc.Text()) {
-				return
+				break
 			}
 		}
-	}
 
-	return f, &err
+		return sc.Err()
+	})
 }
 
 // Lines produces an iterator over the text lines in r.
@@ -40,19 +36,15 @@ func Words(r io.Reader) (iter.Seq[string], *error) {
 // The caller can dereference the returned error pointer to check for errors
 // but only after iteration is done.
 func Lines(r io.Reader) (iter.Seq[string], *error) {
-	var err error
-
-	f := func(yield func(string) bool) {
+	return Err(func(yield func(string) bool) error {
 		sc := bufio.NewScanner(r)
 		for sc.Scan() {
 			if !yield(sc.Text()) {
-				return
+				break
 			}
 		}
-		err = sc.Err()
-	}
-
-	return f, &err
+		return sc.Err()
+	})
 }
 
 // LongLines produces an iterator of readers,

--- a/map.go
+++ b/map.go
@@ -15,23 +15,18 @@ func Map[T, U any](inp iter.Seq[T], f func(T) U) iter.Seq[U] {
 // If the mapping function returns an error,
 // iteration stops and the error is available by dereferencing the returned pointer.
 func Mapx[T, U any](inp iter.Seq[T], f func(T) (U, error)) (iter.Seq[U], *error) {
-	var err error
-
-	g := func(yield func(U) bool) {
+	return Err(func(yield func(U) bool) error {
 		for val := range inp {
-			var out U
-
-			out, err = f(val)
+			out, err := f(val)
 			if err != nil {
-				return
+				return err
 			}
 			if !yield(out) {
-				return
+				return nil
 			}
 		}
-	}
-
-	return g, &err
+		return nil
+	})
 }
 
 // Map2 returns an iterator over the pairs of values of inp transformed by the function f.
@@ -48,22 +43,16 @@ func Map2[T1, U1, T2, U2 any](inp iter.Seq2[T1, U1], f func(T1, U1) (T2, U2)) it
 // If the mapping function returns an error,
 // iteration stops and the error is available by dereferencing the returned pointer.
 func Map2x[T1, U1, T2, U2 any](inp iter.Seq2[T1, U1], f func(T1, U1) (T2, U2, error)) (iter.Seq2[T2, U2], *error) {
-	var err error
-
-	g := func(yield func(T2, U2) bool) {
+	return Err2(func(yield func(T2, U2) bool) error {
 		for k, v := range inp {
-			var out1 T2
-			var out2 U2
-
-			out1, out2, err = f(k, v)
+			out1, out2, err := f(k, v)
 			if err != nil {
-				return
+				return err
 			}
 			if !yield(out1, out2) {
-				return
+				return nil
 			}
 		}
-	}
-
-	return g, &err
+		return nil
+	})
 }

--- a/sql.go
+++ b/sql.go
@@ -33,18 +33,15 @@ type QueryerContext interface {
 // The caller may check for errors by dereferencing the returned error pointer,
 // but only after the iterator is fully consumed.
 func SQL[T any](ctx context.Context, db QueryerContext, query string, args ...any) (iter.Seq[T], *error) {
-	rows, err := db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return Empty[T], &err
-	}
-
-	f := func(yield func(T) bool) {
+	return Err(func(yield func(T) bool) error {
+		rows, err := db.QueryContext(ctx, query, args...)
+		if err != nil {
+			return err
+		}
 		err = sqlHelper[T](ctx, rows, yield)
 		err2 := rows.Close()
-		err = errors.Join(err, err2)
-	}
-
-	return f, &err
+		return errors.Join(err, err2)
+	})
 }
 
 // Prepared is like [SQL] but uses a prepared [sql.Stmt] instead of a database and string query.
@@ -53,18 +50,15 @@ func SQL[T any](ctx context.Context, db QueryerContext, query string, args ...an
 // The caller may check for errors by dereferencing the returned error pointer,
 // but only after the iterator is fully consumed.
 func Prepared[T any](ctx context.Context, stmt *sql.Stmt, args ...any) (iter.Seq[T], *error) {
-	rows, err := stmt.QueryContext(ctx, args...)
-	if err != nil {
-		return Empty[T], &err
-	}
-
-	f := func(yield func(T) bool) {
+	return Err(func(yield func(T) bool) error {
+		rows, err := stmt.QueryContext(ctx, args...)
+		if err != nil {
+			return err
+		}
 		err = sqlHelper[T](ctx, rows, yield)
 		err2 := rows.Close()
-		err = errors.Join(err, err2)
-	}
-
-	return f, &err
+		return errors.Join(err, err2)
+	})
 }
 
 type sqlKindError struct {


### PR DESCRIPTION
This PR adds `Err` and `Err2`, adapter functions that can turn an error-returning function into an `iter.Seq` or an `iter.Seq2`.