### PR TITLE
Add Peeker and Peeker2; also FromPull and FromPull2. Deprecate Peek and Peek2.

### DIFF
--- a/dup.go
+++ b/dup.go
@@ -23,8 +23,8 @@ func Dup[T any](inp iter.Seq[T], n int) []iter.Seq[T] {
 		offsets   = make([]int, n)
 		result    []iter.Seq[T]
 
-		nrunning int32 = int32(n)
-		done           = make(chan struct{})
+		nrunning = int32(n)
+		done     = make(chan struct{})
 	)
 
 	go func() {

--- a/example_test.go
+++ b/example_test.go
@@ -157,15 +157,18 @@ func ExamplePages() {
 	// [10]
 }
 
-func ExamplePeek() {
+func ExamplePeeker() {
 	var (
 		ints   = seqs.Ints(1, 1)     // All integers starting at 1
 		first3 = seqs.Limit(ints, 3) // First three integers
 	)
 
-	peeked, ok, first3 := seqs.Peek(first3)
+	next, peek, stop := seqs.Peeker(first3)
+	defer stop()
+
+	peeked, ok := peek()
 	if ok {
-		all3 := slices.Collect(first3)
+		all3 := slices.Collect(seqs.FromPull(next))
 		fmt.Printf("Peeked value is %d, full sequence is %v\n", peeked, all3)
 	} else {
 		fmt.Println("Sequence is empty")

--- a/limit.go
+++ b/limit.go
@@ -20,7 +20,7 @@ func Limit[T any](seq iter.Seq[T], n int) iter.Seq[T] {
 	}
 }
 
-// Limit returns an iterator over the elements of seq that stops after n pairs
+// Limit2 returns an iterator over the elements of seq that stops after n pairs
 // (or when seq is exhausted, whichever comes first).
 func Limit2[T, U any](seq iter.Seq2[T, U], n int) iter.Seq2[T, U] {
 	return func(yield func(T, U) bool) {

--- a/peek.go
+++ b/peek.go
@@ -14,6 +14,8 @@ import "iter"
 // is to pass the iterator to [Drain].
 // Another is to call [iter.Pull] on it
 // and immediately call the returned "stop" function.
+//
+// Deprecated: Ensuring this does not leak resources is not as ergonomic as it can be. Use [Peeker] instead.
 func Peek[T any](inp iter.Seq[T]) (T, bool, iter.Seq[T]) {
 	next, stop := iter.Pull(inp)
 
@@ -42,6 +44,38 @@ func Peek[T any](inp iter.Seq[T]) (T, bool, iter.Seq[T]) {
 	return zero, false, Empty[T]
 }
 
+// Peeker is like [iter.Pull] but adds the ability to "peek" at the next value in a sequence without consuming it.
+// As with iter.Pull, callers must be sure to call stop (usually via defer)
+// when finished with the resulting "peeker."
+func Peeker[T any](inp iter.Seq[T]) (next, peek func() (T, bool), stop func()) {
+	next1, stop := iter.Pull(inp)
+
+	var peeked *T
+
+	next = func() (T, bool) {
+		if peeked != nil {
+			result := *peeked
+			peeked = nil
+			return result, true
+		}
+		return next1()
+	}
+
+	peek = func() (T, bool) {
+		if peeked != nil {
+			return *peeked, true
+		}
+		val, ok := next1()
+		if !ok {
+			return val, false
+		}
+		peeked = &val
+		return val, true
+	}
+
+	return next, peek, stop
+}
+
 // Peek2 returns the first pair of values in the given iterator.
 // If the iterator is empty, the returned boolean is false, otherwise it's true.
 // The first pair of the input iterator, if there is one, is consumed.
@@ -54,6 +88,8 @@ func Peek[T any](inp iter.Seq[T]) (T, bool, iter.Seq[T]) {
 // is to pass the iterator to [Drain2].
 // Another is to call [iter.Pull2] on it
 // and immediately call the returned "stop" function.
+//
+// Deprecated: Ensuring this does not leak resources is not as ergonomic as it can be. Use [Peeker2] instead.
 func Peek2[T, U any](inp iter.Seq2[T, U]) (T, U, bool, iter.Seq2[T, U]) {
 	next, stop := iter.Pull2(inp)
 
@@ -83,4 +119,39 @@ func Peek2[T, U any](inp iter.Seq2[T, U]) (T, U, bool, iter.Seq2[T, U]) {
 		zeroU U
 	)
 	return zeroT, zeroU, false, Empty2[T, U]
+}
+
+// Peeker2 is like [iter.Pull2] but adds the ability to "peek" at the next pair of values in a sequence without consuming them.
+// As with iter.Pull2, callers must be sure to call stop (usually via defer)
+// when finished with the resulting "peeker."
+func Peeker2[T, U any](inp iter.Seq2[T, U]) (next, peek func() (T, U, bool), stop func()) {
+	next1, stop := iter.Pull2(inp)
+
+	var (
+		peekedT *T
+		peekedU *U
+	)
+
+	next = func() (T, U, bool) {
+		if peekedT != nil {
+			resultT, resultU := *peekedT, *peekedU
+			peekedT, peekedU = nil, nil
+			return resultT, resultU, true
+		}
+		return next1()
+	}
+
+	peek = func() (T, U, bool) {
+		if peekedT != nil {
+			return *peekedT, *peekedU, true
+		}
+		valT, valU, ok := next1()
+		if !ok {
+			return valT, valU, false
+		}
+		peekedT, peekedU = &valT, &valU
+		return valT, valU, true
+	}
+
+	return next, peek, stop
 }

--- a/peek_test.go
+++ b/peek_test.go
@@ -54,3 +54,67 @@ func TestPeek2(t *testing.T) {
 		t.Error("got ok, want !ok")
 	}
 }
+
+func TestPeeker(t *testing.T) {
+	var (
+		ints   = Ints(1, 1)
+		first3 = Limit(ints, 3)
+	)
+
+	next, peek, stop := Peeker(first3)
+	defer stop()
+
+	got, ok := peek()
+	if !ok {
+		t.Error("got !ok, want ok")
+	}
+	if got != 1 {
+		t.Errorf("got %d, want 1", got)
+	}
+
+	gotOrig := slices.Collect(FromPull(next))
+	wantOrig := []int{1, 2, 3}
+	if !slices.Equal(gotOrig, wantOrig) {
+		t.Errorf("got %v, want %v", gotOrig, wantOrig)
+	}
+
+	_, peek, stop = Peeker(Empty[int])
+	defer stop()
+
+	if _, ok = peek(); ok {
+		t.Error("got ok, want !ok")
+	}
+}
+
+func TestPeeker2(t *testing.T) {
+	var (
+		ints    = Ints(1, 1)
+		squares = Map(Ints(1, 1), func(i int) int { return i * i })
+		zipped  = ZipVals(ints, squares)
+		first3  = Limit2(zipped, 3)
+	)
+
+	next, peek, stop := Peeker2(first3)
+	defer stop()
+
+	gotA, gotB, ok := peek()
+	if !ok {
+		t.Error("got !ok, want ok")
+	}
+	if gotA != 1 || gotB != 1 {
+		t.Errorf("got %d,%d, want 1,1", gotA, gotB)
+	}
+
+	gotOrig := slices.Collect(ToPairs(FromPull2(next)))
+	wantOrig := []Pair[int, int]{{1, 1}, {2, 4}, {3, 9}}
+	if !slices.Equal(gotOrig, wantOrig) {
+		t.Errorf("got %v, want %v", gotOrig, wantOrig)
+	}
+
+	_, peek, stop = Peeker2(Empty2[int, int])
+	defer stop()
+
+	if _, _, ok = peek(); ok {
+		t.Error("got ok, want !ok")
+	}
+}

--- a/seqs.go
+++ b/seqs.go
@@ -1,3 +1,4 @@
+// Package seqs is a collection of utilities for working with Go iterators.
 package seqs
 
 import (
@@ -9,6 +10,38 @@ import (
 // From creates an iterator over the given items.
 func From[T any](items ...T) iter.Seq[T] {
 	return slices.Values(items)
+}
+
+// FromPull creates an [iter.Seq] from a pull iterator
+// (such as is created by [iter.Pull]).
+func FromPull[T any](next func() (T, bool)) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for {
+			val, ok := next()
+			if !ok {
+				return
+			}
+			if !yield(val) {
+				return
+			}
+		}
+	}
+}
+
+// FromPull2 creates an [iter.Seq2] from a pull iterator
+// (such as is created by [iter.Pull2]).
+func FromPull2[T, U any](next func() (T, U, bool)) iter.Seq2[T, U] {
+	return func(yield func(T, U) bool) {
+		for {
+			valT, valU, ok := next()
+			if !ok {
+				return
+			}
+			if !yield(valT, valU) {
+				return
+			}
+		}
+	}
 }
 
 // Pair is a generic pair of values.

--- a/sql.go
+++ b/sql.go
@@ -75,7 +75,7 @@ func sqlHelper[T any](ctx context.Context, rows *sql.Rows, yield func(T) bool) e
 		tt = reflect.TypeOf(t)
 	)
 
-	if isSqlNull(tt) {
+	if isSQLNull(tt) {
 		return sqlHelperScalar[T](ctx, rows, yield)
 	}
 
@@ -91,7 +91,7 @@ func sqlHelper[T any](ctx context.Context, rows *sql.Rows, yield func(T) bool) e
 	}
 }
 
-func isSqlNull(tt reflect.Type) bool {
+func isSQLNull(tt reflect.Type) bool {
 	if tt.PkgPath() != "database/sql" {
 		return false
 	}

--- a/zip.go
+++ b/zip.go
@@ -2,7 +2,7 @@ package seqs
 
 import "iter"
 
-// A Zipped is a pair of zipped values, one of which may be missing,
+// Zipped is a pair of zipped values, one of which may be missing,
 // drawn from two different sequences.
 type Zipped[V1, V2 any] struct {
 	V1  V1
@@ -49,6 +49,8 @@ func Zip[V1, V2 any](x iter.Seq[V1], y iter.Seq[V2]) iter.Seq[Zipped[V1, V2]] {
 	}
 }
 
+// A Zipped2 is a pair of zipped key-value pairs,
+// one of which may be missing, drawn from two different sequences.
 type Zipped2[K1, V1, K2, V2 any] struct {
 	K1  K1
 	V1  V1
@@ -97,9 +99,9 @@ func Zip2[K1, V1, K2, V2 any](x iter.Seq2[K1, V1], y iter.Seq2[K2, V2]) iter.Seq
 	}
 }
 
-// Zip takes two iterators and produces a new iterator containing pairs of corresponding elements.
+// ZipVals takes two iterators and produces a new iterator containing pairs of corresponding elements.
 // If one input iterator ends before the other,
-// Zip produces zero values of the appropriate type in constructing pairs.
+// ZipVals produces zero values of the appropriate type in constructing pairs.
 func ZipVals[T, U any](t iter.Seq[T], u iter.Seq[U]) iter.Seq2[T, U] {
 	return func(yield func(T, U) bool) {
 		next, stop := iter.Pull(u)


### PR DESCRIPTION
This PR adds `Peeker` and `Peeker2`; also `FromPull` and `FromPull2`. It also deprecates `Peek` and `Peek2`. And it incidentally fixes some doc comments.